### PR TITLE
[Fix] Only keep system prompt when history messages are empty.

### DIFF
--- a/example/chatbot_streamlit/app.py
+++ b/example/chatbot_streamlit/app.py
@@ -550,7 +550,12 @@ async def process_chat(user_input: str):
             )
             await st.session_state.chat_session.initialize()
             # Keep the history messages from the new chat session.
-            st.session_state.history_messages = st.session_state.chat_session.messages
+            if not st.session_state.history_messages:
+                # If the history messages are not set, we need to get the
+                # system prompt from the chat session.
+                st.session_state.history_messages = (
+                    st.session_state.chat_session.messages
+                )
             st.session_state.session_config_hash = current_config_hash
             # st.toast("New chat session initialized.", icon="🎈")  # User feedback
         else:


### PR DESCRIPTION
### Description

Issue refer to the message https://github.com/keli-wen/mcp_chatbot/pull/14#issuecomment-2833293997, thanks to @jizhuwojiaopaozong

Due to Streamlit's rerunning feature, the chat session is initialized each time.

In the original logic, this meant we would **always** retrieve messages from a new chat session, which contained **only** the system prompt. Consequently, all previous chat history was lost.

With the fix, we now only retrieve the system message once, specifically when the history messages are empty.
