### PR TITLE
fix: resolve two bugs (cleanup & tool role)

### DIFF
--- a/mcp_chatbot/chat/session.py
+++ b/mcp_chatbot/chat/session.py
@@ -94,7 +94,7 @@ class ChatSession:
 
     async def cleanup_clients(self) -> None:
         """Clean up all client resources."""
-        for client in self.clients:
+        for client in reversed(self.clients):
             try:
                 await client.cleanup()
             except Exception as e:
@@ -387,7 +387,7 @@ class ChatSession:
 
             # Format tool results and add to message history
             tool_results = self._format_tool_results(tool_calls)
-            self.messages.append({"role": "system", "content": tool_results})
+            self.messages.append({"role": "user", "content": tool_results})
             tool_result_formatted = self._format_tool_results(
                 tool_calls, for_display=True
             )


### PR DESCRIPTION
I found two bugs when I develop the project, 
one is that when I add other servers to the mcp, it will be cleaned in a wrong order, describe as bellows:
<img width="1370" height="485" alt="error1" src="https://github.com/user-attachments/assets/9bcf9c6e-a825-4fb2-9766-8bbeb7e35ab3" />
I resolve the bug by reserving the cleanup order
another bug I found is that when I use deepseek V3 to build the mcp, it will get wrong for the chatbot_terminal, I resolve the problem by modifying the role of the response from mcp tools from "system" to "user".